### PR TITLE
WiP: Fix Edge Cases for Customized `docsUrl`

### DIFF
--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -138,7 +138,7 @@ A React component to organize text and images.
   className="myCustomClass"
   contents={[
     {
-      title: `[Learn](${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/tutorial.html)`,
+      title: `[Learn](${getCustomizedPathname(siteConfig)}/tutorial.html)`,
       content: 'Learn how to use this project',
       image: siteConfig.baseUrl + 'img/learn.png',
       imageAlt: 'Learn how to use this project',

--- a/docs/api-pages.md
+++ b/docs/api-pages.md
@@ -138,7 +138,7 @@ A React component to organize text and images.
   className="myCustomClass"
   contents={[
     {
-      title: `[Learn](${siteConfig.baseUrl}${getDocsUrl(siteConfig.docsUrl)}/tutorial.html)`,
+      title: `[Learn](${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/tutorial.html)`,
       content: 'Learn how to use this project',
       image: siteConfig.baseUrl + 'img/learn.png',
       imageAlt: 'Learn how to use this project',

--- a/docs/guides-translation.md
+++ b/docs/guides-translation.md
@@ -65,7 +65,7 @@ You can also include an optional description attribute to give more context to a
 <p>
 ```
 
-> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
+> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${getCustomizedPathname(siteConfig)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
 
 ## Gathering Strings to Translate
 

--- a/docs/guides-translation.md
+++ b/docs/guides-translation.md
@@ -65,7 +65,7 @@ You can also include an optional description attribute to give more context to a
 <p>
 ```
 
-> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${siteConfig.baseUrl}${getDocsUrl(siteConfig.docsUrl)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
+> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
 
 ## Gathering Strings to Translate
 

--- a/v1/examples/basics/pages/en/help.js
+++ b/v1/examples/basics/pages/en/help.js
@@ -14,10 +14,10 @@ const GridBlock = CompLibrary.GridBlock;
 
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 
-const {getDocsUrl} = require('../../../lib/server/routing');
+const {getDocsUrl} = require('../../../lib/server/utils');
 
 function docUrl(doc, language) {
-  return `${siteConfig.baseUrl}${getDocsUrl(siteConfig.docsUrl)}/${
+  return `${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/${
     language ? `${language}/` : ''
   }${doc}`;
 }

--- a/v1/examples/basics/pages/en/help.js
+++ b/v1/examples/basics/pages/en/help.js
@@ -14,10 +14,13 @@ const GridBlock = CompLibrary.GridBlock;
 
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 
-const {getDocsUrl} = require('../../../lib/server/utils');
+const {getCustomizedPathname} = require('../../../lib/server/utils');
 
 function docUrl(doc, language) {
-  return `${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/${
+  // TODO: this is no longer the encouraged way of writing it
+  // with customized link the user should know what their baseUrl + docsUrl are
+  // and not make silly decisions about it
+  return `${getCustomizedPathname(siteConfig)}/${
     language ? `${language}/` : ''
   }${doc}`;
 }

--- a/v1/lib/core/DocsLayout.js
+++ b/v1/lib/core/DocsLayout.js
@@ -18,7 +18,12 @@ const renderMarkdown = require('./renderMarkdown');
 const Site = require('./Site.js');
 const translation = require('../server/translation.js');
 const docs = require('../server/docs.js');
-const {idx, getGitLastUpdatedTime, getGitLastUpdatedBy} = require('./utils.js');
+const {
+  idx,
+  getGitLastUpdatedTime,
+  getGitLastUpdatedBy,
+  removeDuplicateLeadingSlashes,
+} = require('./utils.js');
 
 // component used to generate whole webpage for docs, including sidebar/header/footer
 class DocsLayout extends React.Component {
@@ -29,9 +34,11 @@ class DocsLayout extends React.Component {
         .relative(from, to)
         .replace('\\', '/')
         .replace(/^\.\.\//, '') + extension;
-    return url.resolve(
-      `${this.props.config.baseUrl}${this.props.metadata.permalink}`,
-      relativeHref,
+    return removeDuplicateLeadingSlashes(
+      url.resolve(
+        `${this.props.config.baseUrl}${this.props.metadata.permalink}`,
+        relativeHref,
+      ),
     );
   };
 

--- a/v1/lib/core/nav/HeaderNav.js
+++ b/v1/lib/core/nav/HeaderNav.js
@@ -22,7 +22,7 @@ const readMetadata = require('../../server/readMetadata.js');
 
 readMetadata.generateMetadataDocs();
 const Metadata = require('../metadata.js');
-const {idx, getPath} = require('../utils.js');
+const {idx, getPath, removeDuplicateLeadingSlashes} = require('../utils.js');
 
 const extension = siteConfig.cleanUrl ? '' : '.html';
 
@@ -56,7 +56,12 @@ class LanguageDropDown extends React.Component {
         }
         return (
           <li key={lang.tag}>
-            <a href={getPath(href, this.props.cleanUrl)}>{lang.name}</a>
+            <a
+              href={removeDuplicateLeadingSlashes(
+                getPath(href, this.props.cleanUrl),
+              )}>
+              {lang.name}
+            </a>
           </li>
         );
       });
@@ -223,7 +228,9 @@ class HeaderNav extends React.Component {
     const i18n = translation[this.props.language];
     return (
       <li key={`${link.label}page`} className={itemClasses}>
-        <a href={href} target={link.external ? '_blank' : '_self'}>
+        <a
+          href={removeDuplicateLeadingSlashes(href)}
+          target={link.external ? '_blank' : '_self'}>
           {idx(i18n, ['localized-strings', 'links', link.label]) || link.label}
         </a>
       </li>
@@ -300,10 +307,10 @@ class HeaderNav extends React.Component {
         <div className="headerWrapper wrapper">
           <header>
             <a
-              href={
+              href={removeDuplicateLeadingSlashes(
                 this.props.baseUrl +
-                (env.translation.enabled ? this.props.language : '')
-              }>
+                  (env.translation.enabled ? this.props.language : ''),
+              )}>
               {siteConfig.headerIcon && (
                 <img
                   className="logo"
@@ -316,7 +323,7 @@ class HeaderNav extends React.Component {
               )}
             </a>
             {env.versioning.enabled && (
-              <a href={versionsLink}>
+              <a href={removeDuplicateLeadingSlashes(versionsLink)}>
                 <h3>{this.props.version || env.versioning.defaultVersion}</h3>
               </a>
             )}

--- a/v1/lib/core/nav/SideNav.js
+++ b/v1/lib/core/nav/SideNav.js
@@ -10,7 +10,7 @@ const classNames = require('classnames');
 
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const translation = require('../../server/translation.js');
-const {getPath, idx} = require('../utils.js');
+const {getPath, idx, removeDuplicateLeadingSlashes} = require('../utils.js');
 
 class SideNav extends React.Component {
   // return appropriately translated category string
@@ -97,7 +97,9 @@ class SideNav extends React.Component {
     });
     return (
       <li className={itemClasses} key={linkMetadata.id}>
-        <a className="navItem" href={this.getLink(linkMetadata)}>
+        <a
+          className="navItem"
+          href={removeDuplicateLeadingSlashes(this.getLink(linkMetadata))}>
           {this.getLocalizedString(linkMetadata)}
         </a>
       </li>

--- a/v1/lib/core/utils.js
+++ b/v1/lib/core/utils.js
@@ -111,6 +111,12 @@ function getGitLastUpdatedBy(filepath) {
   return commit ? commit.author : null;
 }
 
+function removeDuplicateLeadingSlashes(urlWithLeadingSlash) {
+  // replace more than one leading slash to one
+  // used when either docsUrl / baseUrl / langPart has colliding leading slashes
+  return urlWithLeadingSlash.replace(/^\/+/, '/');
+}
+
 module.exports = {
   blogPostHasTruncateMarker,
   extractBlogPostBeforeTruncate,
@@ -119,4 +125,5 @@ module.exports = {
   getPath,
   removeExtension,
   idx,
+  removeDuplicateLeadingSlashes,
 };

--- a/v1/lib/server/__tests__/routing.test.js
+++ b/v1/lib/server/__tests__/routing.test.js
@@ -7,8 +7,8 @@
 const routing = require('../routing.js');
 
 describe('Blog routing', () => {
-  const blogRegex = routing.blog('/');
-  const blogRegex2 = routing.blog('/react/');
+  const blogRegex = routing.blog({baseUrl: '/'});
+  const blogRegex2 = routing.blog({baseUrl: '/react/'});
 
   test('valid blog', () => {
     expect('/blog/test.html').toMatch(blogRegex);
@@ -34,8 +34,8 @@ describe('Blog routing', () => {
 });
 
 describe('Docs routing', () => {
-  const docsRegex = routing.docs('/', 'docs');
-  const docsRegex2 = routing.docs('/reason/', 'docs');
+  const docsRegex = routing.docs({baseUrl: '/', docsUrl: 'docs'});
+  const docsRegex2 = routing.docs({baseUrl: '/reason/', docsUrl: 'docs'});
 
   test('valid docs', () => {
     expect('/docs/en/test.html').toMatch(docsRegex);
@@ -87,8 +87,8 @@ describe('Dot routing', () => {
 });
 
 describe('Feed routing', () => {
-  const feedRegex = routing.feed('/');
-  const feedRegex2 = routing.feed('/reason/');
+  const feedRegex = routing.feed({baseUrl: '/'});
+  const feedRegex2 = routing.feed({baseUrl: '/reason/'});
 
   test('valid feed url', () => {
     expect('/blog/atom.xml').toMatch(feedRegex);
@@ -137,8 +137,8 @@ describe('Extension-less url routing', () => {
 });
 
 describe('Page routing', () => {
-  const pageRegex = routing.page('/', 'docs');
-  const pageRegex2 = routing.page('/reason/', 'docs');
+  const pageRegex = routing.page({baseUrl: '/', docsUrl: 'docs'});
+  const pageRegex2 = routing.page({baseUrl: '/reason/', docsUrl: 'docs'});
 
   test('valid page url', () => {
     expect('/index.html').toMatch(pageRegex);
@@ -164,8 +164,8 @@ describe('Page routing', () => {
 });
 
 describe('Sitemap routing', () => {
-  const sitemapRegex = routing.sitemap('/');
-  const sitemapRegex2 = routing.sitemap('/reason/');
+  const sitemapRegex = routing.sitemap({baseUrl: '/'});
+  const sitemapRegex2 = routing.sitemap({baseUrl: '/reason/'});
 
   test('valid sitemap url', () => {
     expect('/sitemap.xml').toMatch(sitemapRegex);

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -15,9 +15,9 @@ const readMetadata = require('./readMetadata.js');
 const {insertTOC} = require('../core/toc.js');
 const {getPath} = require('../core/utils.js');
 
-const {getDocsUrl} = require('./routing.js');
+const {getDocsUrl} = require('./utils.js');
 
-const docsUrl = getDocsUrl(siteConfig.docsUrl);
+const docsUrl = getDocsUrl(siteConfig);
 
 function getFilePath(metadata) {
   if (!metadata) {

--- a/v1/lib/server/docs.js
+++ b/v1/lib/server/docs.js
@@ -15,9 +15,9 @@ const readMetadata = require('./readMetadata.js');
 const {insertTOC} = require('../core/toc.js');
 const {getPath} = require('../core/utils.js');
 
-const {getDocsUrl} = require('./utils.js');
+const {getCustomizedPathname} = require('./utils.js');
 
-const docsUrl = getDocsUrl(siteConfig);
+const customizedPathname = getCustomizedPathname(siteConfig);
 
 function getFilePath(metadata) {
   if (!metadata) {
@@ -117,10 +117,7 @@ function replaceAssetsLink(oldContent) {
     }
     return fencedBlock
       ? line
-      : line.replace(
-          /\]\(assets\//g,
-          `](${siteConfig.baseUrl}${docsUrl}/assets/`,
-        );
+      : line.replace(/\]\(assets\//g, `](${customizedPathname}/assets/`);
   });
   return lines.join('\n');
 }
@@ -149,7 +146,7 @@ function getMarkup(rawContent, mdToHtml, metadata) {
 function getRedirectMarkup(metadata) {
   if (
     !env.translation.enabled ||
-    !metadata.permalink.includes(`${docsUrl}/en`)
+    !metadata.permalink.includes(`${customizedPathname}/en`)
   ) {
     return null;
   }

--- a/v1/lib/server/generate.js
+++ b/v1/lib/server/generate.js
@@ -35,8 +35,8 @@ async function execute() {
   const imageminOptipng = require('imagemin-optipng');
   const imageminSvgo = require('imagemin-svgo');
   const imageminGifsicle = require('imagemin-gifsicle');
-  const {getDocsUrl} = require('./routing.js');
-  const docsUrl = getDocsUrl(siteConfig.docsUrl);
+  const {getDocsUrl} = require('./utils.js');
+  const docsUrl = getDocsUrl(siteConfig);
 
   commander.option('--skip-image-compression').parse(process.argv);
 

--- a/v1/lib/server/metadataUtils.js
+++ b/v1/lib/server/metadataUtils.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+import {removeDuplicateLeadingSlashes} from './utils';
 // split markdown header
 function splitHeader(content) {
   // New line characters need to handle all operating systems.
@@ -79,7 +79,7 @@ function mdToHtml(Metadata, baseUrl, docsUrl) {
     } else {
       htmlLink = htmlLink.replace(`/${docsUrl}/`, `/${docsUrl}/VERSION/`);
     }
-    result[metadata.source] = htmlLink;
+    result[metadata.source] = removeDuplicateLeadingSlashes(htmlLink);
   });
   return result;
 }

--- a/v1/lib/server/readMetadata.js
+++ b/v1/lib/server/readMetadata.js
@@ -170,9 +170,7 @@ function processMetadata(file, refDir) {
     versionPart = 'next/';
   }
 
-  metadata.permalink = `${getDocsUrl(
-    siteConfig.docsUrl,
-  )}/${langPart}${versionPart}${metadata.id}.html`;
+  metadata.permalink = `${docsUrl}/${langPart}${versionPart}${metadata.id}.html`;
 
   // change ids previous, next
   metadata.localized_id = metadata.id;

--- a/v1/lib/server/readMetadata.js
+++ b/v1/lib/server/readMetadata.js
@@ -33,9 +33,9 @@ const SupportedHeaderFields = new Set([
   'custom_edit_url',
 ]);
 
-const {getDocsUrl} = require('./routing.js');
+const {getDocsUrl} = require('./utils.js');
 
-const docsUrl = getDocsUrl(siteConfig.docsUrl);
+const docsUrl = getDocsUrl(siteConfig);
 
 let allSidebars;
 if (fs.existsSync(`${CWD}/sidebars.json`)) {
@@ -170,7 +170,9 @@ function processMetadata(file, refDir) {
     versionPart = 'next/';
   }
 
-  metadata.permalink = `${docsUrl}/${langPart}${versionPart}${metadata.id}.html`;
+  metadata.permalink = `${docsUrl}/${langPart}${versionPart}${
+    metadata.id
+  }.html`;
 
   // change ids previous, next
   metadata.localized_id = metadata.id;

--- a/v1/lib/server/readMetadata.js
+++ b/v1/lib/server/readMetadata.js
@@ -170,9 +170,9 @@ function processMetadata(file, refDir) {
     versionPart = 'next/';
   }
 
-  metadata.permalink = `${docsUrl}/${langPart}${versionPart}${
-    metadata.id
-  }.html`;
+  metadata.permalink = utils.removeDuplicateLeadingSlashes(
+    `/${docsUrl}/${langPart}${versionPart}${metadata.id}.html`,
+  );
 
   // change ids previous, next
   metadata.localized_id = metadata.id;
@@ -248,7 +248,7 @@ function generateMetadataDocs() {
             baseMetadata.permalink = baseMetadata.permalink
               .toString()
               .replace(
-                new RegExp(`^${docsUrl}/en/`),
+                new RegExp(`${docsUrl}/en/`),
                 `${docsUrl}/${currentLanguage}/`,
               );
           }

--- a/v1/lib/server/routing.js
+++ b/v1/lib/server/routing.js
@@ -10,7 +10,12 @@ function blog(baseUrl) {
   return new RegExp(`^${baseUrl}blog/.*html$`);
 }
 
-function docs(baseUrl, docsUrl = DOCS_URL) {
+function docs(baseUrl, docsUrl) {
+  if (`${baseUrl}${docsUrl}` === '/') {
+    // precisely one of `baseUrl` and `docsUrl` is `/`, and the other is empty
+    // collides with the next slash
+    return new RegExp(`^/.*/(?!index).*html$`);
+  }
   return new RegExp(`^${baseUrl}${docsUrl}/.*html$`);
 }
 
@@ -26,11 +31,9 @@ function noExtension() {
   return /\/[^.]*\/?$/;
 }
 
-function page(baseUrl, docsUrl = DOCS_URL) {
+function page(baseUrl, docsUrl) {
   const gr = regex => regex.toString().replace(/(^\/|\/$)/gm, '');
-  return new RegExp(
-    `(?!${gr(docs(baseUrl, docsUrl))}|${gr(blog(baseUrl))})^${baseUrl}.*.html$`,
-  );
+  return new RegExp(`(?!${gr(blog(baseUrl))})^${baseUrl}.*.html$`);
 }
 
 function sitemap(baseUrl) {

--- a/v1/lib/server/routing.js
+++ b/v1/lib/server/routing.js
@@ -4,8 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-const DOCS_URL = 'docs';
+import {DOCS_URL} from './utils';
 
 function blog(baseUrl) {
   return new RegExp(`^${baseUrl}blog/.*html$`);
@@ -38,10 +37,6 @@ function sitemap(baseUrl) {
   return new RegExp(`^${baseUrl}sitemap.xml$`);
 }
 
-function getDocsUrl(docsUrl) {
-  return docsUrl || DOCS_URL;
-}
-
 module.exports = {
   blog,
   docs,
@@ -50,6 +45,4 @@ module.exports = {
   page,
   noExtension,
   sitemap,
-  getDocsUrl,
-  DOCS_URL,
 };

--- a/v1/lib/server/routing.js
+++ b/v1/lib/server/routing.js
@@ -4,40 +4,43 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {DOCS_URL} from './utils';
+import {getCustomizedPathname} from './utils';
 
-function blog(baseUrl) {
-  return new RegExp(`^${baseUrl}blog/.*html$`);
+function blog(siteConfig) {
+  return new RegExp(`^${siteConfig.baseUrl}blog/.*html$`);
 }
 
-function docs(baseUrl, docsUrl) {
-  if (`${baseUrl}${docsUrl}` === '/') {
+function docs(siteConfig) {
+  const customizedPathname = getCustomizedPathname(siteConfig);
+  if (customizedPathname === '/') {
     // precisely one of `baseUrl` and `docsUrl` is `/`, and the other is empty
     // collides with the next slash
     return new RegExp(`^/.*/(?!index).*html$`);
   }
-  return new RegExp(`^${baseUrl}${docsUrl}/.*html$`);
+  return new RegExp(`^${getCustomizedPathname(siteConfig)}/.*html$`);
 }
 
 function dotfiles() {
   return /(?!.*html$)^\/.*\.[^\n/]+$/;
 }
 
-function feed(baseUrl) {
-  return new RegExp(`^${baseUrl}blog/(feed.xml|atom.xml)$`);
+function feed(siteConfig) {
+  return new RegExp(`^${siteConfig.baseUrl}blog/(feed.xml|atom.xml)$`);
 }
 
 function noExtension() {
   return /\/[^.]*\/?$/;
 }
 
-function page(baseUrl, docsUrl) {
+function page(siteConfig) {
   const gr = regex => regex.toString().replace(/(^\/|\/$)/gm, '');
-  return new RegExp(`(?!${gr(blog(baseUrl))})^${baseUrl}.*.html$`);
+  return new RegExp(
+    `(?!${gr(blog(siteConfig.baseUrl))})^${siteConfig.baseUrl}.*.html$`,
+  );
 }
 
-function sitemap(baseUrl) {
-  return new RegExp(`^${baseUrl}sitemap.xml$`);
+function sitemap(siteConfig) {
+  return new RegExp(`^${siteConfig.baseUrl}sitemap.xml$`);
 }
 
 module.exports = {

--- a/v1/lib/server/server.js
+++ b/v1/lib/server/server.js
@@ -27,6 +27,7 @@ function execute(port) {
   const feed = require('./feed');
   const sitemap = require('./sitemap');
   const routing = require('./routing.js');
+  const {getDocsUrl} = require('./utils');
   const CWD = process.cwd();
   const join = path.join;
   const sep = path.sep;
@@ -108,7 +109,7 @@ function execute(port) {
   reloadSiteConfig();
 
   const app = express();
-  const docsUrl = routing.getDocsUrl(siteConfig.docsUrl);
+  const docsUrl = getDocsUrl(siteConfig);
 
   app.get(routing.docs(siteConfig.baseUrl, docsUrl), (req, res, next) => {
     const url = decodeURI(req.path.toString().replace(siteConfig.baseUrl, ''));

--- a/v1/lib/server/server.js
+++ b/v1/lib/server/server.js
@@ -6,6 +6,7 @@
  */
 
 /* eslint-disable no-cond-assign */
+import {removeDuplicateLeadingSlashes} from './utils';
 
 function execute(port) {
   const extractTranslations = require('../write-translations');
@@ -111,11 +112,8 @@ function execute(port) {
   const app = express();
   const docsUrl = getDocsUrl(siteConfig);
 
-  app.get(routing.docs(siteConfig.baseUrl, docsUrl), (req, res, next) => {
-    const url =
-      `${siteConfig.baseUrl}${docsUrl}` === '/' // precisely one of them is '/', the other is ''
-        ? req.path.toString()
-        : decodeURI(req.path.toString().replace(siteConfig.baseUrl, ''));
+  app.get(routing.docs(siteConfig), (req, res, next) => {
+    const url = removeDuplicateLeadingSlashes(req.path);
     const metadata =
       Metadata[
         Object.keys(Metadata).find(id => Metadata[id].permalink === url)
@@ -145,7 +143,7 @@ function execute(port) {
     res.send(docs.getMarkup(rawContent, mdToHtml, metadata));
   });
 
-  app.get(routing.sitemap(siteConfig.baseUrl), (req, res) => {
+  app.get(routing.sitemap(siteConfig), (req, res) => {
     sitemap((err, xml) => {
       if (err) {
         res.status(500).send('Sitemap error');
@@ -156,7 +154,7 @@ function execute(port) {
     });
   });
 
-  app.get(routing.feed(siteConfig.baseUrl), (req, res, next) => {
+  app.get(routing.feed(siteConfig), (req, res, next) => {
     res.set('Content-Type', 'application/rss+xml');
     const file = req.path
       .toString()
@@ -170,7 +168,7 @@ function execute(port) {
     next();
   });
 
-  app.get(routing.blog(siteConfig.baseUrl), (req, res, next) => {
+  app.get(routing.blog(siteConfig), (req, res, next) => {
     // Regenerate the blog metadata in case it has changed. Consider improving
     // this to regenerate on file save rather than on page request.
     reloadMetadataBlog();
@@ -196,7 +194,7 @@ function execute(port) {
     }
   });
 
-  app.get(routing.page(siteConfig.baseUrl, docsUrl), (req, res, next) => {
+  app.get(routing.page(siteConfig), (req, res, next) => {
     // Look for user-provided HTML file first.
     let htmlFile = req.path.toString().replace(siteConfig.baseUrl, '');
     htmlFile = join(CWD, 'pages', htmlFile);

--- a/v1/lib/server/sitemap.js
+++ b/v1/lib/server/sitemap.js
@@ -16,9 +16,9 @@ const utils = require('../core/utils');
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
 
-const {getDocsUrl} = require('./utils.js');
+const {getCustomizedPathname} = require('./utils.js');
 
-const docsUrl = getDocsUrl(siteConfig);
+const customizedPathname = getCustomizedPathname(siteConfig);
 
 const readMetadata = require('./readMetadata.js');
 
@@ -76,8 +76,8 @@ module.exports = function(callback) {
       const docUrl = utils.getPath(doc.permalink, siteConfig.cleanUrl);
       const links = enabledLanguages.map(lang => {
         const langUrl = docUrl.replace(
-          `${docsUrl}/en/`,
-          `${docsUrl}/${lang.tag}/`,
+          `${customizedPathname}/en/`,
+          `${customizedPathname}/${lang.tag}/`,
         );
         return {lang: lang.tag, url: langUrl};
       });

--- a/v1/lib/server/sitemap.js
+++ b/v1/lib/server/sitemap.js
@@ -16,9 +16,9 @@ const utils = require('../core/utils');
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
 
-const {getDocsUrl} = require('./routing.js');
+const {getDocsUrl} = require('./utils.js');
 
-const docsUrl = getDocsUrl(siteConfig.docsUrl);
+const docsUrl = getDocsUrl(siteConfig);
 
 const readMetadata = require('./readMetadata.js');
 

--- a/v1/lib/server/utils.js
+++ b/v1/lib/server/utils.js
@@ -14,17 +14,19 @@ const escapeStringRegexp = require('escape-string-regexp');
 const DOCS_URL = 'docs';
 
 function getDocsUrl(siteConfig) {
-  return Object.hasOwnProperty.call(siteConfig, 'docsUrl')
-    ? siteConfig.docsUrl
-    : DOCS_URL;
+  return siteConfig.docsUrl || DOCS_URL;
 }
 
 function getCustomizedPathname(siteConfig) {
   const baseUrl = siteConfig.baseUrl;
-  const docsUrl = Object.hasOwnProperty.call(siteConfig, 'docsUrl')
-    ? siteConfig.docsUrl
-    : DOCS_URL;
-  return `${baseUrl}${docsUrl}`.replace(/^\/+/, '/');
+  const docsUrl = getDocsUrl(siteConfig);
+  return removeDuplicateLeadingSlashes(`${baseUrl}${docsUrl}`);
+}
+
+function removeDuplicateLeadingSlashes(urlWithLeadingSlash) {
+  // replace more than one leading slash to one
+  // used when either docsUrl / baseUrl / langPart has colliding leading slashes
+  return urlWithLeadingSlash.replace(/^\/+/, '/');
 }
 
 function getSubDir(file, refDir) {
@@ -90,4 +92,5 @@ module.exports = {
   autoPrefixCss,
   getCustomizedPathname,
   getDocsUrl,
+  removeDuplicateLeadingSlashes,
 };

--- a/v1/lib/server/utils.js
+++ b/v1/lib/server/utils.js
@@ -11,6 +11,14 @@ const postcss = require('postcss');
 const path = require('path');
 const escapeStringRegexp = require('escape-string-regexp');
 
+const DOCS_URL = 'docs';
+
+function getDocsUrl(siteConfig) {
+  return Object.hasOwnProperty.call(siteConfig, 'docsUrl')
+    ? siteConfig.docsUrl
+    : DOCS_URL;
+}
+
 function getSubDir(file, refDir) {
   const subDir = path.dirname(path.relative(refDir, file)).replace(/\\/g, '/');
   return subDir !== '.' && !subDir.includes('..') ? subDir : null;
@@ -72,4 +80,5 @@ module.exports = {
   isSeparateCss,
   minifyCss,
   autoPrefixCss,
+  getDocsUrl,
 };

--- a/v1/lib/server/utils.js
+++ b/v1/lib/server/utils.js
@@ -14,7 +14,9 @@ const escapeStringRegexp = require('escape-string-regexp');
 const DOCS_URL = 'docs';
 
 function getDocsUrl(siteConfig) {
-  return siteConfig.docsUrl || DOCS_URL;
+  return Object.hasOwnProperty.call(siteConfig, 'docsUrl')
+    ? siteConfig.docsUrl
+    : DOCS_URL;
 }
 
 function getCustomizedPathname(siteConfig) {

--- a/v1/lib/server/utils.js
+++ b/v1/lib/server/utils.js
@@ -19,6 +19,14 @@ function getDocsUrl(siteConfig) {
     : DOCS_URL;
 }
 
+function getCustomizedPathname(siteConfig) {
+  const baseUrl = siteConfig.baseUrl;
+  const docsUrl = Object.hasOwnProperty.call(siteConfig, 'docsUrl')
+    ? siteConfig.docsUrl
+    : DOCS_URL;
+  return `${baseUrl}${docsUrl}`.replace(/^\/+/, '/');
+}
+
 function getSubDir(file, refDir) {
   const subDir = path.dirname(path.relative(refDir, file)).replace(/\\/g, '/');
   return subDir !== '.' && !subDir.includes('..') ? subDir : null;
@@ -80,5 +88,6 @@ module.exports = {
   isSeparateCss,
   minifyCss,
   autoPrefixCss,
+  getCustomizedPathname,
   getDocsUrl,
 };

--- a/v1/lib/server/versionFallback.js
+++ b/v1/lib/server/versionFallback.js
@@ -17,9 +17,7 @@ const utils = require('./utils.js');
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
 
-const {getDocsUrl} = require('./utils.js');
-
-const docsUrl = getDocsUrl(siteConfig);
+const docsUrl = utils.getDocsUrl(siteConfig);
 
 const ENABLE_TRANSLATION = fs.existsSync(`${CWD}/languages.js`);
 
@@ -180,16 +178,17 @@ function processVersionMetadata(file, version, useVersion, language) {
     : `version-${useVersion}/${path.basename(file)}`;
 
   const latestVersion = versions[0];
-
+  let permalink;
   if (!ENABLE_TRANSLATION && !siteConfig.useEnglishUrl) {
-    metadata.permalink = `${docsUrl}/${
-      version !== latestVersion ? `${version}/` : ''
-    }${metadata.original_id}.html`;
+    permalink = `/${docsUrl}/${version !== latestVersion ? `${version}/` : ''}${
+      metadata.original_id
+    }.html`;
   } else {
-    metadata.permalink = `${docsUrl}/${language}/${
+    permalink = `/${docsUrl}/${language}/${
       version !== latestVersion ? `${version}/` : ''
     }${metadata.original_id}.html`;
   }
+  metadata.permalink = utils.removeDuplicateLeadingSlashes(permalink);
   metadata.id = metadata.id.replace(
     `version-${useVersion}-`,
     `version-${version}-`,

--- a/v1/lib/server/versionFallback.js
+++ b/v1/lib/server/versionFallback.js
@@ -17,9 +17,9 @@ const utils = require('./utils.js');
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
 
-const {getDocsUrl} = require('./routing.js');
+const {getDocsUrl} = require('./utils.js');
 
-const docsUrl = getDocsUrl(siteConfig.docsUrl);
+const docsUrl = getDocsUrl(siteConfig);
 
 const ENABLE_TRANSLATION = fs.existsSync(`${CWD}/languages.js`);
 

--- a/v1/website/core/utils.js
+++ b/v1/website/core/utils.js
@@ -1,0 +1,9 @@
+function removeDuplicateLeadingSlashes(urlWithLeadingSlash) {
+  // replace more than one leading slash to one
+  // used when either docsUrl / baseUrl / langPart has colliding leading slashes
+  return urlWithLeadingSlash.replace(/^\/+/, '/');
+}
+
+export default {
+  removeDuplicateLeadingSlashes,
+};

--- a/v1/website/pages/en/help.js
+++ b/v1/website/pages/en/help.js
@@ -12,16 +12,16 @@ const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const translate = require('../../server/translate.js').translate;
-const {getDocsUrl} = require('../../server/utils.js');
+const {getCustomizedPathname} = require('../../server/utils.js');
 
 class Help extends React.Component {
   render() {
     const supportLinks = [
       {
         title: <translate>Browse the docs</translate>,
-        content: `Learn more about Docusaurus using the [official documentation](${
-          siteConfig.baseUrl
-        }${getDocsUrl(siteConfig)}/${this.props.language}/installation).`,
+        content: `Learn more about Docusaurus using the [official documentation](${getCustomizedPathname(
+          siteConfig,
+        )}/${this.props.language}/installation).`,
       },
       {
         title: <translate>Discord</translate>,

--- a/v1/website/pages/en/help.js
+++ b/v1/website/pages/en/help.js
@@ -12,7 +12,7 @@ const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const translate = require('../../server/translate.js').translate;
-const {getDocsUrl} = require('../../server/routing.js');
+const {getDocsUrl} = require('../../server/utils.js');
 
 class Help extends React.Component {
   render() {
@@ -21,9 +21,7 @@ class Help extends React.Component {
         title: <translate>Browse the docs</translate>,
         content: `Learn more about Docusaurus using the [official documentation](${
           siteConfig.baseUrl
-        }${getDocsUrl(siteConfig.docsUrl)}/${
-          this.props.language
-        }/installation).`,
+        }${getDocsUrl(siteConfig)}/${this.props.language}/installation).`,
       },
       {
         title: <translate>Discord</translate>,

--- a/v1/website/pages/en/index.js
+++ b/v1/website/pages/en/index.js
@@ -14,9 +14,9 @@ const GridBlock = CompLibrary.GridBlock;
 const Showcase = require(`${process.cwd()}/core/Showcase.js`);
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const translate = require('../../server/translate.js').translate;
-const {getDocsUrl} = require('../../server/routing.js');
+const {getDocsUrl} = require('../../server/utils.js');
 
-const docsUrl = getDocsUrl(siteConfig.docsUrl);
+const docsUrl = getDocsUrl(siteConfig);
 
 class Button extends React.Component {
   render() {

--- a/v1/website/pages/en/index.js
+++ b/v1/website/pages/en/index.js
@@ -14,15 +14,19 @@ const GridBlock = CompLibrary.GridBlock;
 const Showcase = require(`${process.cwd()}/core/Showcase.js`);
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 const translate = require('../../server/translate.js').translate;
-const {getDocsUrl} = require('../../server/utils.js');
+const {getCustomizedPathname} = require('../../server/utils.js');
+const {removeDuplicateLeadingSlashes} = require('../../core/utils.js');
 
-const docsUrl = getDocsUrl(siteConfig);
+const customizedPathname = getCustomizedPathname(siteConfig);
 
 class Button extends React.Component {
   render() {
     return (
       <div className="pluginWrapper buttonWrapper">
-        <a className="button" href={this.props.href} target={this.props.target}>
+        <a
+          className="button"
+          href={removeDuplicateLeadingSlashes(this.props.href)}
+          target={this.props.target}>
           {this.props.children}
         </a>
       </div>
@@ -55,11 +59,11 @@ class HomeSplash extends React.Component {
                 <div className="promoRow">
                   <div className="pluginRowBlock">
                     <Button
-                      href={`
-                        ${siteConfig.baseUrl}${docsUrl}/${
-                        this.props.language
-                      }/installation
-                        `}>
+                      href={removeDuplicateLeadingSlashes(
+                        `${customizedPathname}/${
+                          this.props.language
+                        }/installation`.trim(),
+                      )}>
                       <translate>Get Started</translate>
                     </Button>
                     <Button href="https://github.com/facebook/Docusaurus">
@@ -91,9 +95,12 @@ class Index extends React.Component {
               contents={[
                 {
                   content: `Save time and focus on your project's documentation. Simply
-                    write docs and blog posts with [Markdown](${
-                      siteConfig.baseUrl
-                    }${docsUrl}/${this.props.language}/doc-markdown)
+                    write docs and blog posts with [Markdown](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        '/doc-markdown',
+                    )})
                     and Docusaurus will publish a set of static html files ready
                     to serve.`,
                   image: `${siteConfig.baseUrl}img/markdown.png`,
@@ -102,9 +109,12 @@ class Index extends React.Component {
                   title: <translate>Powered by Markdown</translate>,
                 },
                 {
-                  content: `[Extend or customize](${
-                    siteConfig.baseUrl
-                  }${docsUrl}${this.props.language}/api-pages)
+                  content: `[Extend or customize](${removeDuplicateLeadingSlashes(
+                    customizedPathname +
+                      '/' +
+                      this.props.language +
+                      '/api-pages',
+                  )})
                     your project's layout by reusing React. Docusaurus can be
                     extended while reusing the same header and footer.`,
                   image: `${siteConfig.baseUrl}img/react.svg`,
@@ -113,9 +123,12 @@ class Index extends React.Component {
                   title: <translate>Built Using React</translate>,
                 },
                 {
-                  content: `[Localization](${siteConfig.baseUrl}${docsUrl}${
-                    this.props.language
-                  }/translation)
+                  content: `[Localization](${removeDuplicateLeadingSlashes(
+                    customizedPathname +
+                      '/' +
+                      this.props.language +
+                      '/translation',
+                  )})
                     comes pre-configured. Use [Crowdin](https://crowdin.com/) to translate your docs
                     into over 70 languages.`,
                   image: `${siteConfig.baseUrl}img/translation.svg`,
@@ -133,9 +146,12 @@ class Index extends React.Component {
               contents={[
                 {
                   content: `Support users on all versions of your project. Document
-                    [versioning](${siteConfig.baseUrl}${docsUrl}/${
-                    this.props.language
-                  }/versioning)
+                    [versioning](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        '/versioning',
+                    )})
                     helps you keep documentation in sync with project releases.`,
                   image: `${siteConfig.baseUrl}img/versioning.svg`,
                   imageAlign: 'top',
@@ -143,11 +159,9 @@ class Index extends React.Component {
                   title: <translate>Document Versioning</translate>,
                 },
                 {
-                  content: `Make it easy for your community to [find](${
-                    siteConfig.baseUrl
-                  }${docsUrl}/${
-                    this.props.language
-                  }/search) what they need in your documentation.
+                  content: `Make it easy for your community to [find](${removeDuplicateLeadingSlashes(
+                    customizedPathname + '/' + this.props.language + '/search',
+                  )}) what they need in your documentation.
                     We proudly support [Algolia documentation search](https://www.algolia.com/).`,
                   image: `${siteConfig.baseUrl}img/search.svg`,
                   imageAlign: 'top',
@@ -162,9 +176,12 @@ class Index extends React.Component {
             <GridBlock
               contents={[
                 {
-                  content: `Get [up and running](${
-                    siteConfig.baseUrl
-                  }${docsUrl}${this.props.language}/site-creation)
+                  content: `Get [up and running](${removeDuplicateLeadingSlashes(
+                    customizedPathname +
+                      '/' +
+                      this.props.language +
+                      '/site-creation',
+                  )})
                     quickly without having to worry about site design.`,
                   imageAlign: 'right',
                   image: `${siteConfig.baseUrl}img/docusaurus_speed.svg`,
@@ -180,12 +197,18 @@ class Index extends React.Component {
               contents={[
                 {
                   content: `Make design and documentation changes by using the included
-                    [live server](${siteConfig.baseUrl}${docsUrl}/${
-                    this.props.language
-                  }/site-preparation#verifying-installation).
-                    [Publish](${siteConfig.baseUrl}${docsUrl}/${
-                    this.props.language
-                  }/publishing)
+                    [live server](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        'site-preparation#verifying-installation',
+                    )}).
+                    [Publish](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        '/publishing',
+                    )})
                     your site to GitHub pages or other static file hosts
                     manually, using a script, or with continuous integration
                     like CircleCI.`,
@@ -203,18 +226,27 @@ class Index extends React.Component {
               contents={[
                 {
                   content: `Docusaurus currently provides support to help your website
-                    use [translations](${siteConfig.baseUrl}${docsUrl}${
+                    use [translations](${customizedPathname}${
                     this.props.language
                   }/translation),
-                    [search](${siteConfig.baseUrl}${docsUrl}/${
-                    this.props.language
-                  }/search),
-                    and [versioning](${siteConfig.baseUrl}${docsUrl}${
-                    this.props.language
-                  }/versioning),
-                    along with some other special [documentation markdown features](${
-                      siteConfig.baseUrl
-                    }${docsUrl}/${this.props.language}/doc-markdown).
+                    [search](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        '/search',
+                    )}),
+                    and [versioning](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        '/versioning',
+                    )}),
+                    along with some other special [documentation markdown features](${removeDuplicateLeadingSlashes(
+                      customizedPathname +
+                        '/' +
+                        this.props.language +
+                        '/doc-markdown',
+                    )}).
                     If you have ideas for useful features, feel free to
                     contribute on [GitHub](https://github.com/facebook/docusaurus)!`,
                   imageAlign: 'right',

--- a/v1/website/pages/en/versions.js
+++ b/v1/website/pages/en/versions.js
@@ -15,9 +15,9 @@ const CWD = process.cwd();
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
 const versions = require(`${CWD}/versions.json`);
-const {getDocsUrl} = require('../../../lib/server/utils.js');
+const {getCustomizedPathname} = require('../../../lib/server/utils.js');
 
-const docsUrl = getDocsUrl(siteConfig);
+const customizedPathname = getCustomizedPathname(siteConfig);
 
 function Versions(props) {
   const latestVersion = versions[0];
@@ -39,7 +39,7 @@ function Versions(props) {
                 <th>{latestVersion}</th>
                 <td>
                   <a
-                    href={`${siteConfig.baseUrl}${docsUrl}/${
+                    href={`${customizedPathname}/${
                       props.language
                     }/installation`}>
                     Documentation
@@ -61,7 +61,7 @@ function Versions(props) {
                 <th>master</th>
                 <td>
                   <a
-                    href={`${siteConfig.baseUrl}${docsUrl}/${
+                    href={`${customizedPathname}/${
                       props.language
                     }/next/installation`}>
                     Documentation
@@ -86,7 +86,7 @@ function Versions(props) {
                       <th>{version}</th>
                       <td>
                         <a
-                          href={`${siteConfig.baseUrl}${docsUrl}/${
+                          href={`${customizedPathname}/${
                             props.language
                           }/${version}/installation`}>
                           Documentation

--- a/v1/website/pages/en/versions.js
+++ b/v1/website/pages/en/versions.js
@@ -15,9 +15,9 @@ const CWD = process.cwd();
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
 const versions = require(`${CWD}/versions.json`);
-const {getDocsUrl} = require('../../../lib/server/routing.js');
+const {getDocsUrl} = require('../../../lib/server/utils.js');
 
-const docsUrl = getDocsUrl(siteConfig.docsUrl);
+const docsUrl = getDocsUrl(siteConfig);
 
 function Versions(props) {
   const latestVersion = versions[0];

--- a/v1/website/siteConfig.js
+++ b/v1/website/siteConfig.js
@@ -13,7 +13,7 @@ const siteConfig = {
   tagline: 'Easy to Maintain Open Source Documentation Websites',
   url: 'https://docusaurus.io',
   baseUrl: '/',
-  docsUrl: 'docs',
+  docsUrl: '',
   organizationName: 'facebook',
   projectName: 'Docusaurus',
   cname: 'docusaurus.io',

--- a/v1/website/siteConfig.js
+++ b/v1/website/siteConfig.js
@@ -13,7 +13,7 @@ const siteConfig = {
   tagline: 'Easy to Maintain Open Source Documentation Websites',
   url: 'https://docusaurus.io',
   baseUrl: '/',
-  docsUrl: '',
+  docsUrl: '/',
   organizationName: 'facebook',
   projectName: 'Docusaurus',
   cname: 'docusaurus.io',

--- a/v1/website/versioned_docs/version-1.3.3/guides-translation.md
+++ b/v1/website/versioned_docs/version-1.3.3/guides-translation.md
@@ -66,7 +66,7 @@ You can also include an optional description attribute to give more context to a
 <p>
 ```
 
-> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${siteConfig.baseUrl}${getDocsUrl(siteConfig.docsUrl)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
+> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
 
 ## Gathering Strings to Translate
 

--- a/v1/website/versioned_docs/version-1.3.3/guides-translation.md
+++ b/v1/website/versioned_docs/version-1.3.3/guides-translation.md
@@ -66,7 +66,7 @@ You can also include an optional description attribute to give more context to a
 <p>
 ```
 
-> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${siteConfig.baseUrl}${getDocsUrl(siteConfig)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
+> The `<translate>` tag generally works well on pure strings. If you have a string like "Docusaurus currently provides support to help your website use [translations](${getCustomizedPathname(siteConfig)}/${this.props.language}/translation.html)", wrapping the `<translation>` tag around that entire string will cause issues because of the markdown linking, etc. Your options are to not translate those strings, or spread a bunch of `<translate>` tags amongst the pure substrings of that string.
 
 ## Gathering Strings to Translate
 


### PR DESCRIPTION
Hey @domcorvasce ,

Sorry to be bothering you again!

I found out a bit more issue. In short:
It doesn't work with `docsUrl: '/'` or `docsUrl: ''`, which is actually the use case we have in mind.

So I've made some attempts to fix it. There is some breaking changes to your previous implementation. 

## Major Changes
- Moved `getDocsUrl` out from `routing.js` to `util.js` because it is a util, and is not responsible for routing
- Changed `getDocsUrl` to using `siteConfig` instead of `siteConfig.docsUrl`
- Changed the fallback mechanism to using

There are a few remaining issue to fix. Mainly we need to make docs routing work with languages and versioning. Perhaps @endiliey can provide some pointers?

## Implementation Thoughts
Cases for `docsUrl`:
- Existing sites: Currently not providing `docsUrl`, we should make sure they are not affected. This is provided by having `getDocsUrl` fallback to `docs` when it does not find `docsUrl` using `Object.hasOwnObject`
- New sites with any non-whitespace, non-slash `docsUrl`: this is the major intended use case
- New sites with `docsUrl` of white spaces or slashes: this is the tricky part (explained below)

The reason why it is tricky is that the current implementation uses the first part of pathname as for routing. It assumes that the site is organized into:
- docs/
- blog/
- ... other customized pages such as help/, etc
By freeing up `docs/` to be anything, it collides with other routing. Plus each of those cases is complicated by language and versioning modifiers. So the edge cases are a bit tricky to handle..

## Checklist
- [x] Added `removeDuplicateLeadingSlashes` util to make sure there is only
one leading slash
- [ ] Fix edge cases for routing:
  - [x] `docsUrl: ''`
  - [x] `docsUrl: '/'`
  - [ ] make it work with languages
  - [ ] make it work with versioning

Regarding [#914](https://github.com/facebook/Docusaurus/pull/914)